### PR TITLE
Autoincrement minor and major if patch or minor overcome specific value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ node_modules
 
 *.sublime-project
 *.sublime-workspace
+
+.idea

--- a/README.md
+++ b/README.md
@@ -152,6 +152,21 @@ Causes the current minor version to be incremented by 1
 
 Sets the current minor version to have the specified value
 
+## maxMinor(value)
+
+Sets the current max minor value.
+If minor value exceeds this value, the current value is decreased of max value until it is under the max value. While the minor value is over the max value, major value is incresed of 1 unity 
+
+Example: final result is 6.0.10
+
+```js
+    versiony
+        .version('5.99.10')
+        .minor()
+        .maxMinor(99)
+        .end().version
+```
+
 ## patch()
 
 Causes the current patch version to be incremented by 1
@@ -161,6 +176,32 @@ Causes the current patch version to be incremented by 1
 Sets the current patch version to have the specified value
 
 Calling major() twice does not cause the increment to be applied twice. It is only applied once. Same for minor() and patch()
+
+## maxPatch(value)
+
+Sets the current max patch value.
+If patch value exceeds this value, the current value is decreased of max value until it is under the max value. While the patch value is over the max value, minor value is incresed of 1 unity 
+
+Example: final result is 4.1.0
+
+```js
+    versiony
+        .version('4.0.99')
+        .patch()
+        .maxPatch(99)
+        .end().version
+```
+
+Example: final result is 5.0.0
+
+```js
+    versiony
+        .version('4.99.99')
+        .patch()
+        .maxPatch(99)
+        .maxMinor(99)
+        .end().version
+```
 
 ## newMajor
 

--- a/index.js
+++ b/index.js
@@ -88,6 +88,18 @@ var versiony = (function(){
             return this
         },
 
+        maxPatch: function(maxValue){
+            this.model.maxPatch.apply(this.model, arguments)
+
+            return this
+        },
+
+        maxMinor: function(maxValue){
+            this.model.maxMinor.apply(this.model, arguments)
+
+            return this
+        },
+
         from: function(s){
             source = s || 'package.json'
 

--- a/model.js
+++ b/model.js
@@ -34,6 +34,12 @@ module.exports = function(){
             reset: reset
         },
 
+        maxValues = {
+            major: null,
+            minor: null,
+            patch: null
+        },
+
         shouldSet = function(name, v){
             if (v != null){
                 parts[name]      = v
@@ -44,6 +50,10 @@ module.exports = function(){
             }
         },
 
+        setMaxValue = function(name, v){
+            maxValues[name] = v
+        },
+
         prepareValue = function(name, array){
             var index = indexes[name]
 
@@ -52,6 +62,12 @@ module.exports = function(){
             }
             if (parts[name] != null){
                 array[index] = parts[name]
+            }
+            if (maxValues[name] != null){
+                while (array[index] > maxValues[name]){
+                    array[index] -= (maxValues[name]+1)
+                    array[index-1]++
+                }
             }
         },
 
@@ -81,6 +97,14 @@ module.exports = function(){
 
         patch : function(v){
             shouldSet('patch', v)
+        },
+
+        maxPatch : function(v){
+            setMaxValue('patch', v)
+        },
+
+        maxMinor : function(v){
+            setMaxValue('minor', v)
         },
 
         toString : function(){
@@ -123,9 +147,9 @@ module.exports = function(){
             !value[1] && (value[1] = 0)
             !value[2] && (value[2] = 0)
 
-            prepareValue('major', value)
-            prepareValue('minor', value)
             prepareValue('patch', value)
+            prepareValue('minor', value)
+            prepareValue('major', value)
 
             var result = value.map(function(v){
                 return parseInt(v, 10)

--- a/model.js
+++ b/model.js
@@ -60,14 +60,14 @@ module.exports = function(){
             if (increments[name]){
                 array[index]++
             }
-            if (parts[name] != null){
-                array[index] = parts[name]
-            }
             if (maxValues[name] != null){
                 while (array[index] > maxValues[name]){
-                    array[index] -= (maxValues[name]+1)
-                    array[index-1]++
+                  array[index] -= (maxValues[name]+1)
+                  array[index-1]++
                 }
+            }
+            if (parts[name] != null){
+                array[index] = parts[name]
             }
         },
 

--- a/package.json
+++ b/package.json
@@ -1,29 +1,29 @@
 {
-  "name": "versiony",
-  "version": "1.4.0",
-  "description": "A module to increment version number for your code/module. Support for npm/bower/custom files.",
-  "main": "index.js",
-  "scripts": {
-    "test": "echo no tests yet"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/ciena-blueplanet/versiony.git"
-  },
-  "keywords": [
-    "version",
-    "manager",
-    "version manager",
-    "bump",
-    "package.json",
-    "bower version",
-    "bower",
-    "version"
-  ],
-  "author": "Radu Brehar",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/ciena-blueplanet/versiony/issues"
-  },
-  "dependencies": {}
+    "name": "versiony",
+    "version": "9.4.0",
+    "description": "A module to increment version number for your code/module. Support for npm/bower/custom files.",
+    "main": "index.js",
+    "scripts": {
+        "test": "echo no tests yet"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git://github.com/ciena-blueplanet/versiony.git"
+    },
+    "keywords": [
+        "version",
+        "manager",
+        "version manager",
+        "bump",
+        "package.json",
+        "bower version",
+        "bower",
+        "version"
+    ],
+    "author": "Radu Brehar",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/ciena-blueplanet/versiony/issues"
+    },
+    "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "versiony",
-    "version": "3.4.0",
+    "version": "1.4.0",
     "description": "A module to increment version number for your code/module. Support for npm/bower/custom files.",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "versiony",
-    "version": "9.4.0",
+    "version": "1.4.0",
     "description": "A module to increment version number for your code/module. Support for npm/bower/custom files.",
     "main": "index.js",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "versiony",
-    "version": "1.4.0",
+    "version": "3.4.0",
     "description": "A module to increment version number for your code/module. Support for npm/bower/custom files.",
     "main": "index.js",
     "scripts": {

--- a/test.js
+++ b/test.js
@@ -8,3 +8,12 @@ versiony
 var r = versiony.get()
 
 console.log(r)
+
+var r = versiony
+  .version('2.99.99')
+  .patch()
+  .maxPatch(99)
+  .maxMinor(99)
+  .end().version
+
+console.log(r)


### PR DESCRIPTION
Hi,

I created a script that every time it runs it updates a version number with this library.
But, since there is no logic behind, it just upgrades the patch number with patch().
I think it should be useful to have a specific method for incrementing in a smartest way, like, if the version is 3.45.999, doing something like .maxPatch(999).patch() the result should be 3.46.0.
The parameter passed to maxPatch (and maxMinor() as well) should be the max value before resetting patch/minor and increasing minor/major.
Could it be useful for anybody else?
I can write a logic behind this, but since I need to use in many projects I want to know if you are interested in this pull request or I should create a different npm package for it.

Thanks.