### PR TITLE
Fixed return value from .end() and added tests

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -89,7 +89,7 @@ module.exports = (function () {
       }
 
       this.model.set(version)
-      this.initial = version
+      this.initial = this.model.toString()
 
       return this
     },
@@ -103,7 +103,7 @@ module.exports = (function () {
         file = source
       }
 
-      if (file === source && String(this.model.get()) === this.initial) {
+      if (file === source && this.model.get() === this.initial) {
         // skip same file, no change detected
         return this
       }
@@ -140,17 +140,18 @@ module.exports = (function () {
     },
 
     getVersion () {
-      return this.model.get()
+      this.model.get() // to apply the pending changes
+      return this.model.version
     },
 
     get () {
-      return String(this.model.get())
+      return this.model.get()
     },
 
     end (params = {}) {
       const {quiet} = params
       const files = this.model.files().slice()
-      const version = String(this.model.get())
+      const version = this.model.toString()
 
       if (!quiet) {
         if (files.length) {

--- a/lib/model.js
+++ b/lib/model.js
@@ -122,7 +122,7 @@ module.exports = function () {
       prepareValue('patch', this.version)
       prepareValue('preRelease', this.version)
 
-      return this.version
+      return this.toString()
     }
   }
 

--- a/tests/end-spec.js
+++ b/tests/end-spec.js
@@ -1,0 +1,116 @@
+/**
+ * Specify behavior for the .end() API interface
+ */
+
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+const sinon = require('sinon')
+
+chai.use(sinonChai)
+const expect = chai.expect
+
+const versiony = require('../lib/index')
+const logger = require('../lib/logger')
+const utils = require('../lib/utils')
+
+describe('.end()', function () {
+  let sandbox, strip
+  beforeEach(function () {
+    strip = '---------------------------------------------'
+    sandbox = sinon.sandbox.create()
+    sandbox.stub(logger, 'log')
+    sandbox.stub(utils, 'readJsonFile').returns({})
+    sandbox.stub(utils, 'writeJsonFile')
+    versiony.version('1.2.3-alpha.4')
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+    versiony.model.reset()
+  })
+
+  describe('when called without params (and no files updated)', function () {
+    let ret
+    beforeEach(function () {
+      sandbox.stub(versiony.model, 'reset')
+      ret = versiony.end()
+    })
+
+    it('should log a strip', function () {
+      expect(logger.log).to.have.been.calledWith(strip)
+    })
+
+    it('should log a done message', function () {
+      expect(logger.log).to.have.been.calledWith('No file updated.')
+    })
+
+    it('should reset the model', function () {
+      expect(versiony.model.reset).to.have.callCount(1)
+    })
+
+    it('return the correct info,', function () {
+      expect(ret).to.eql({
+        files: [],
+        version: '1.2.3-alpha.4'
+      })
+    })
+  })
+
+  describe('when called without params (and some files updated)', function () {
+    let ret
+    beforeEach(function () {
+      ret = versiony
+        .to('_package.json')
+        .to('_bower.json')
+        .end()
+    })
+
+    it('should log a strip', function () {
+      expect(logger.log).to.have.been.calledWith(strip)
+    })
+
+    it('should log a done message', function () {
+      expect(logger.log).to.have.been.calledWith('Done. New version: 1.2.3-alpha.4')
+    })
+
+    it('should log a files updated message', function () {
+      expect(logger.log).to.have.been.calledWith('Files updated:\n')
+    })
+
+    it('should log the first file updated', function () {
+      expect(logger.log).to.have.been.calledWith('_package.json')
+    })
+
+    it('should log the second file updated', function () {
+      expect(logger.log).to.have.been.calledWith('_bower.json')
+    })
+
+    it('return the correct info,', function () {
+      expect(ret).to.eql({
+        files: ['_package.json', '_bower.json'],
+        version: '1.2.3-alpha.4'
+      })
+    })
+  })
+
+  describe('when called with quiet flag (and some files updated)', function () {
+    let ret
+    beforeEach(function () {
+      ret = versiony
+        .to('_package.json')
+        .to('_bower.json')
+        .end({quiet: true})
+    })
+
+    it('should not log anything', function () {
+      expect(logger.log).to.have.callCount(0)
+    })
+
+    it('return the correct info,', function () {
+      expect(ret).to.eql({
+        files: ['_package.json', '_bower.json'],
+        version: '1.2.3-alpha.4'
+      })
+    })
+  })
+})

--- a/tests/from-spec.js
+++ b/tests/from-spec.js
@@ -19,7 +19,6 @@ describe('.from()', function () {
     sandbox = sinon.sandbox.create()
     sandbox.stub(utils, 'readJsonFile')
     sandbox.stub(utils, 'writeJsonFile')
-    sandbox.stub(versiony.model, 'set')
   })
 
   afterEach(function () {
@@ -41,22 +40,8 @@ describe('.from()', function () {
         expect(utils.readJsonFile).to.have.been.calledWith('package.json')
       })
 
-      it('should set the version on the model', function () {
-        expect(versiony.model.set).to.have.been.calledWith({
-          major: 1,
-          minor: 2,
-          patch: 3,
-          preRelease: 'alpha.1'
-        })
-      })
-
       it('should store the initial version', function () {
-        expect(versiony.initial).to.eql({
-          major: 1,
-          minor: 2,
-          patch: 3,
-          preRelease: 'alpha.1'
-        })
+        expect(versiony.initial).to.eql('1.2.3-alpha.1')
       })
     })
 
@@ -69,22 +54,8 @@ describe('.from()', function () {
         expect(utils.readJsonFile).to.have.been.calledWith('_package.json')
       })
 
-      it('should set the version on the model', function () {
-        expect(versiony.model.set).to.have.been.calledWith({
-          major: 1,
-          minor: 2,
-          patch: 3,
-          preRelease: 'alpha.1'
-        })
-      })
-
       it('should store the initial version', function () {
-        expect(versiony.initial).to.eql({
-          major: 1,
-          minor: 2,
-          patch: 3,
-          preRelease: 'alpha.1'
-        })
+        expect(versiony.initial).to.eql('1.2.3-alpha.1')
       })
     })
   })
@@ -94,6 +65,7 @@ describe('.from()', function () {
     beforeEach(function () {
       utils.readJsonFile.returns({})
       sandbox.stub(logger, 'warn')
+      sandbox.stub(versiony.model, 'set')
       ret = versiony.from()
     })
 
@@ -116,6 +88,7 @@ describe('.from()', function () {
     let ret
     beforeEach(function () {
       utils.readJsonFile.throws({foo: 'bar'})
+      sandbox.stub(versiony.model, 'set')
       sandbox.stub(logger, 'error')
       ret = versiony.from()
     })

--- a/tests/get-spec.js
+++ b/tests/get-spec.js
@@ -1,0 +1,52 @@
+/**
+ * Specify behavior for the .get() API interface
+ */
+
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+const sinon = require('sinon')
+
+chai.use(sinonChai)
+const expect = chai.expect
+
+const versiony = require('../lib/index')
+
+describe('.get()', function () {
+  let sandbox
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    versiony.version('1.2.3-alpha.4')
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+    versiony.model.reset()
+  })
+
+  describe('when there are no pending changes', function () {
+    let ret
+    beforeEach(function () {
+      ret = versiony.get()
+    })
+
+    it('should return the value string', function () {
+      expect(ret).to.equal('1.2.3-alpha.4')
+    })
+  })
+
+  describe('when there are pending changes', function () {
+    let ret
+    beforeEach(function () {
+      ret = versiony
+        .major()
+        .minor()
+        .patch()
+        .preRelease()
+        .get()
+    })
+
+    it('should return the updated value string', function () {
+      expect(ret).to.equal('2.3.4-alpha.5')
+    })
+  })
+})

--- a/tests/get-version-spec.js
+++ b/tests/get-version-spec.js
@@ -1,0 +1,62 @@
+/**
+ * Specify behavior for the .getVersion() API interface
+ */
+
+const chai = require('chai')
+const sinonChai = require('sinon-chai')
+const sinon = require('sinon')
+
+chai.use(sinonChai)
+const expect = chai.expect
+
+const versiony = require('../lib/index')
+
+describe('.getVersion()', function () {
+  let sandbox
+  beforeEach(function () {
+    sandbox = sinon.sandbox.create()
+    versiony.version('1.2.3-alpha.4')
+  })
+
+  afterEach(function () {
+    sandbox.restore()
+    versiony.model.reset()
+  })
+
+  describe('when there are no pending changes', function () {
+    let ret
+    beforeEach(function () {
+      ret = versiony.getVersion()
+    })
+
+    it('should return the value', function () {
+      expect(ret).to.eql({
+        major: 1,
+        minor: 2,
+        patch: 3,
+        preRelease: 'alpha.4'
+      })
+    })
+  })
+
+  describe('when there are pending changes', function () {
+    let ret
+    beforeEach(function () {
+      ret = versiony
+        .major()
+        .minor()
+        .patch()
+        .preRelease()
+        .getVersion()
+    })
+
+    it('should return the updated value string', function () {
+      expect(ret).to.eql({
+        major: 2,
+        minor: 3,
+        patch: 4,
+        preRelease: 'alpha.5'
+      })
+    })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

# CHANGELOG
* **Fixed** the return value from `.end()` to include the version string instead of the version object
* **Added** some more tests for existing and new features
